### PR TITLE
fix: active route should skip is omitted in history

### DIFF
--- a/src/components/router/Router.brs
+++ b/src/components/router/Router.brs
@@ -56,7 +56,7 @@ sub resetHistory(rootPath = "" as String)
 end sub
 
 sub _updateHistory()
-  if (m.top.url = "")
+  if (m.top.url = "" OR m.top.activatedRoute.shouldSkip)
     return
   end if
 

--- a/src/components/router/_tests/Router.test.brs
+++ b/src/components/router/_tests/Router.test.brs
@@ -143,6 +143,23 @@ function TestSuite__Router() as Object
     return ts.assertTrue(result)
   end function)
 
+  ts.addTest("navigate - doesn't update history if active route should be skipped", function (ts as Object) as String
+    ' Given
+    data = { path: "/new-path", params: { testParam: "testValue" } }
+    m.top.activatedRoute.path = "/previous-path"
+    m.top.activatedRoute.params = { previousParam: "previousValue" }
+    m.top.activatedRoute.shouldSkip = true
+
+    ' When
+    navigate(data)
+
+    ' Then
+    history = m._history
+    result = (history <> Invalid AND history.count() = 0)
+
+    return ts.assertTrue(result)
+  end function)
+
   ts.addTest("back - returns false if empty history", function (ts as Object) as String
     result = back()
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fixes problem where the active route is not skipped in the history when field `shouldSkip` is `true`.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How can we verify it:

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

1. Add should skip to some route.
2. During the journey, go to that route.
3. From that route navigate to the next route.
4. Press the back button (should trigger `router.back()`).
5. Navigation should not bring you to the previous route.

## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
