### PR TITLE
fix: expose response headers in HttpResponse

### DIFF
--- a/src/components/http/HttpResponse.brs
+++ b/src/components/http/HttpResponse.brs
@@ -67,6 +67,7 @@ function HttpResponse(response as Object) as Object
     responseNode = CreateObject("roSGNode", "Node")
     responseNode.id = m._id
     responseNode.addFields({
+      headers: m._headers,
       httpStatusCode: m._httpStatusCode,
       isSuccess: m._isSuccess,
       rawData: m._data,

--- a/src/components/http/_tests/HttpResponse.test.brs
+++ b/src/components/http/_tests/HttpResponse.test.brs
@@ -13,6 +13,7 @@ function TestSuite__HttpResponse() as Object
       headers: { "Content-Type": "application/json" },
     }
     expectedResult = {
+      headers: { "Content-Type": "application/json" },
       id: props.id,
       httpStatusCode: props.httpStatusCode,
       rawData: ParseJSON(props.rawData),
@@ -23,6 +24,7 @@ function TestSuite__HttpResponse() as Object
     response = HttpResponse(props)
     result = response.toNode().getFields()
     result = {
+      headers: result.headers,
       httpStatusCode: result.httpStatusCode,
       id: result.id,
       rawData: result.rawData,
@@ -43,6 +45,7 @@ function TestSuite__HttpResponse() as Object
       headers: { "Content-Type": "application/json" },
     }
     expectedResult = {
+      headers: { "Content-Type": "application/json" },
       id: props.id,
       httpStatusCode: props.httpStatusCode,
       rawData: ParseJSON(props.rawData),
@@ -53,6 +56,7 @@ function TestSuite__HttpResponse() as Object
     response = HttpResponse(props)
     result = response.toNode().getFields()
     result = {
+      headers: result.headers,
       httpStatusCode: result.httpStatusCode,
       id: result.id,
       rawData: result.rawData,


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #25 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
trivial, one line change

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
This change just exposes the response headers to be publicly visible, demonstrated in the updated unit tests.
<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ N/A ] Write documentation (if required)
- [ N/A ? ] Fix linting errors
- [ ✅ ] Enable "Allow edits from maintainers" for this PR
- [ ✅ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
