### PR TITLE
fix: not calling state update callbacks if kopytko is not mounted

### DIFF
--- a/src/components/renderer/KopytkoUpdater.brs
+++ b/src/components/renderer/KopytkoUpdater.brs
@@ -12,6 +12,8 @@ function KopytkoUpdater(baseStateUpdatedCallback as Function)
   ' when setState is called more than once in a function
   prototype.enqueueStateUpdate = sub (partialState as Object, callback = Invalid as Dynamic)
     m._appendPartialState(partialState)
+    if (NOT m._isMounted()) then return
+
     if (callback <> Invalid) then m._stateUpdatedCallbacks.push(callback)
 
     if (NOT m._isUpdating())


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fixes the problem when `setState` is called before `initKopytko`. Currently, update state callbacks are executed even if a component is not mounted and that may result in an app crash if the `render` function tries to access uninitialized fields.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

`KopytkoUpdater.enqueueStateUpdate` additionally checks if a component is mounted before scheduling state update callbacks.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Usage:
```brightscript
kptk = CreateObject("roSGNode", "Kptk")
kptk.callFunc("setState")
```

Kptk.component.xml
```xml
<?xml version="1.0" encoding="utf-8" ?>
<component name="Kptk" extends="KopytkoGroup">
    <interface>
        <function name="setState" />
    </interface>

    <script type="text/brightscript" uri="Kptk.component.brs" />
    <script type="text/brightscript" uri="Kptk.template.brs" />
</component>

```

Kptk.component.brs
```brightscript
sub constructor()
    m.theme = m.global.theme
end sub
```

Kptk.template.brs
```brightscript
function render() as Object
    return [
        {
            name: "Label"
            props: {
                id: "label"
                color: m.theme.textColor
            }
        }
    ]
end function
```

In this example, calling `setState` will result in an app crash because `render` refers `m.theme` which is `invalid` before `initKopytko` is called.

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [X] Write documentation (if required)
- [X] Fix linting errors
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
