### PR TITLE
fix: allow to render array of elements in root component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@dazn/kopytko-framework",
-      "version": "1.0.2",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@dazn/kopytko-utils": "^2.0.1"

--- a/src/components/renderer/KopytkoDOM.brs
+++ b/src/components/renderer/KopytkoDOM.brs
@@ -64,7 +64,7 @@ function KopytkoDOM() as Object
     rootElement = m._getRootComponent()
 
     for each element in elements
-      if (element.parentId = Invalid)
+      if (Type(element) = "roArray" OR element.parentId = Invalid)
         parentElement = rootElement.top
       else
         parentElement = rootElement[element.parentId]

--- a/src/components/renderer/_tests/kopytkoDOM/KopytkoDOM_updateDOM.test.brs
+++ b/src/components/renderer/_tests/kopytkoDOM/KopytkoDOM_updateDOM.test.brs
@@ -92,6 +92,34 @@ function TestSuite__KopytkoDOM_updateDOM()
     return ts.assertEqual(renderedElement.id, "root", "The element marked to be rendered was not rendered")
   end function)
 
+  ts.addTest("it renders an array of elements", function (ts as Object) as String
+    ' Given
+    vNodes = [
+      {
+        name: "LayoutGroup",
+        props: { id: "child1" },
+      },
+      {
+        name: "LayoutGroup",
+        props: { id: "child2" },
+      }
+    ]
+
+    diffResult = {
+      elementsToRender: [vNodes],
+      elementsToRemove: [],
+      elementsToUpdate: {},
+    }
+
+    ' When
+    ts.kopytkoDOM.updateDOM(diffResult)
+
+    ' Then
+    childCount = m.top.getChildCount()
+
+    return ts.assertEqual(childCount, vNodes.count(), "The elements marked to be rendered were not rendered")
+  end function)
+
   ts.addTest("it removes the elements marked to be removed", function (ts as Object) as String
     ' Given
     ts.kopytkoDOM.renderElement({


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Consider such example code
```brightscript
function render() as Object
  if m.top.content = invalid then return invalid
  
  return [
     {
       name: "Label"
       '....
     },
     {
       name: "Label"
       '....
     }
  ]
end function
```
When the component is the root and after the next render tick (`content` is no longer invalid) Kopytko breaks:
```
Current Function:
063:  sub (elements as Object)
064:      rootElement = m._getRootComponent()
065:  
066:      for each element in elements
067:*       if (element.parentId = Invalid)
068:          parentElement = rootElement.top
069:        else
070:          parentElement = rootElement[element.parentId]
071:        end if
Source Digest(s): 
pkg: dev 1.1.1 f31f77289f1bee3045ec26c97485a566 Kopytko Unit Testing Framework App

Syntax Error. (runtime error &h02) in pkg:/components/renderer/KopytkoDOM.brs(67)
```
## How did you implement it:
When an element is of array type and it is the root component the parent component is one level above it.

## How can we verify it:
Run unit tests 

## Todos:

- [ ] Write documentation (if required)
- [ ] Fix linting errors
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
