### PR TITLE
fix: Ignoring Invalid elements when calculating elements' index in children array

### DIFF
--- a/src/components/renderer/KopytkoDiffUtility.brs
+++ b/src/components/renderer/KopytkoDiffUtility.brs
@@ -69,6 +69,20 @@ function KopytkoDiffUtility() as Object
     m._diffElementChildren(currentElement.children, newElement.children, newElement.props.id)
   end sub
 
+  ' @private
+  prototype._diffElementProps = sub (elementId as String, currentProps as Object, newProps as Object)
+    for each newProp in newProps
+      if (NOT m._assert.deepEqual(currentProps[newProp], newProps[newProp]))
+        ' Create element key in case it doesn't exist yet
+        if (m._diffResult.elementsToUpdate[elementId] = Invalid)
+          m._diffResult.elementsToUpdate[elementId] = { props: {} }
+        end if
+
+        m._diffResult.elementsToUpdate[elementId].props[newProp] = newProps[newProp]
+      end if
+    end for
+  end sub
+
   ' @todo Support elements reordering
   ' @private
   prototype._diffElementChildren = sub (currentChildren as Object, newChildren as Object, parentElementId = Invalid as Dynamic)
@@ -111,20 +125,6 @@ function KopytkoDiffUtility() as Object
     for each child in element.children
       if (child <> Invalid)
         m._markElementToBeRemoved(child)
-      end if
-    end for
-  end sub
-
-  ' @private
-  prototype._diffElementProps = sub (elementId as String, currentProps as Object, newProps as Object)
-    for each newProp in newProps
-      if (NOT m._assert.deepEqual(currentProps[newProp], newProps[newProp]))
-        ' Create element key in case it doesn't exist yet
-        if (m._diffResult.elementsToUpdate[elementId] = Invalid)
-          m._diffResult.elementsToUpdate[elementId] = { props: {} }
-        end if
-
-        m._diffResult.elementsToUpdate[elementId].props[newProp] = newProps[newProp]
       end if
     end for
   end sub

--- a/src/components/renderer/KopytkoDiffUtility.brs
+++ b/src/components/renderer/KopytkoDiffUtility.brs
@@ -61,7 +61,12 @@ function KopytkoDiffUtility() as Object
       return
     end if
 
-    m._diffExistingElement(currentElement, newElement)
+    if (newElement.dynamicProps = Invalid)
+      newElement.dynamicProps = {}
+    end if
+
+    m._diffElementProps(currentElement.props.id, currentElement.dynamicProps, newElement.dynamicProps)
+    m._diffElementChildren(currentElement.children, newElement.children, newElement.props.id)
   end sub
 
   ' @todo Support elements reordering
@@ -85,29 +90,14 @@ function KopytkoDiffUtility() as Object
         nonInvalidNewChildIndex++
         newChild.parentId = parentElementId
 
-        if (currentChildrenMapped[newChild.props.id] = Invalid)
-          m._diffResult.elementsToRender.push(newChild)
-        else
-          m._diffExistingElement(currentChildrenMapped[newChild.props.id], newChild)
-          currentChildrenMapped.delete(newChild.props.id)
-        end if
+        m._diffElement(currentChildrenMapped[newChild.props.id], newChild)
+        currentChildrenMapped.delete(newChild.props.id)
       end if
     end for
 
     for each currentChildIdToRemove in currentChildrenMapped
       m._markElementToBeRemoved(currentChildrenMapped[currentChildIdToRemove])
     end for
-  end sub
-
-  prototype._diffExistingElement = sub (currentElement as Object, newElement as Object)
-    if (newElement.dynamicProps = Invalid)
-      newElement.dynamicProps = {}
-    end if
-
-    m._diffElementProps(currentElement.props.id, currentElement.dynamicProps, newElement.dynamicProps)
-    if (currentElement.children <> Invalid OR newElement.children <> Invalid)
-      m._diffElementChildren(currentElement.children, newElement.children, newElement.props.id)
-    end if
   end sub
 
   ' @private

--- a/src/components/renderer/KopytkoDiffUtility.brs
+++ b/src/components/renderer/KopytkoDiffUtility.brs
@@ -105,7 +105,7 @@ function KopytkoDiffUtility() as Object
     end if
 
     m._diffElementProps(currentElement.props.id, currentElement.dynamicProps, newElement.dynamicProps)
-    if currentElement.children <> Invalid OR newElement.children <> Invalid
+    if (currentElement.children <> Invalid OR newElement.children <> Invalid)
       m._diffElementChildren(currentElement.children, newElement.children, newElement.props.id)
     end if
   end sub

--- a/src/components/renderer/_tests/kopytkoDiffUtility/KopytkoDiffUtility_Main.test.brs
+++ b/src/components/renderer/_tests/kopytkoDiffUtility/KopytkoDiffUtility_Main.test.brs
@@ -7,18 +7,12 @@ function TestSuite__KopytkoDiffUtility_Main()
     ' Given
     vNode = {
       name: "Label",
-      props: {
-        id: "testLabel",
-      },
-      children: [],
+      props: { id: "testLabel" },
     }
 
     newVNode = {
       name: "Label",
-      props: {
-        id: "testLabel",
-      },
-      children: [],
+      props: { id: "testLabel" },
     }
 
     ' When
@@ -36,7 +30,6 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "Label",
         props: { id: "label1" },
-        children: [],
       },
     ])
 
@@ -44,7 +37,6 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "Label",
         props: { id: "label1" },
-        children: [],
       },
     ])
 
@@ -67,12 +59,10 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "Label",
         props: { id: "label1" },
-        children: [],
       },
       {
         name: "Label",
         props: { id: "label2" },
-        children: [],
       },
     ])
 
@@ -80,7 +70,6 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "Label",
         props: { id: "label1" },
-        children: [],
       },
     ])
 
@@ -97,12 +86,10 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "Label",
         props: { id: "label1" },
-        children: [],
       },
       {
         name: "Label",
         props: { id: "label2" },
-        children: [],
       },
     ])
 
@@ -110,7 +97,6 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "Label",
         props: { id: "label1" },
-        children: [],
       },
       Invalid,
     ])
@@ -136,21 +122,18 @@ function TestSuite__KopytkoDiffUtility_Main()
               {
                 name: "Label",
                 props: { id: "label3" },
-                children: [],
               },
             ],
           },
           {
             name: "Label",
             props: { id: "label4" },
-            children: [],
           },
         ],
       },
       {
         name: "Label",
         props: { id: "label5" },
-        children: [],
       },
     ])
 
@@ -159,7 +142,6 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "Label",
         props: { id: "label5" },
-        children: [],
       },
     ])
 
@@ -179,7 +161,6 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "Label",
         props: { id: "label1" },
-        children: [],
       },
     ])
 
@@ -187,12 +168,10 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "Label",
         props: { id: "label1" },
-        children: [],
       },
       {
         name: "Label",
         props: { id: "label2" },
-        children: [],
       },
     ])
 
@@ -203,7 +182,6 @@ function TestSuite__KopytkoDiffUtility_Main()
       name: "Label",
       props: { id: "label2" },
       parentid: "root",
-      children: [],
       index: 1,
     }
 
@@ -217,7 +195,6 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "Label",
         props: { id: "label1" },
-        children: [],
       },
       Invalid,
     ])
@@ -226,12 +203,10 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "Label",
         props: { id: "label1" },
-        children: [],
       },
       {
         name: "Label",
         props: { id: "label2" },
-        children: [],
       },
     ])
 
@@ -242,12 +217,42 @@ function TestSuite__KopytkoDiffUtility_Main()
       name: "Label",
       props: { id: "label2" },
       parentid: "root",
-      children: [],
       index: 1,
     }
 
     ' Then
     return ts.assertEqual(labelToRender, expectedLabelToRender, "The new element was not marked to be rendered")
+  end function)
+
+  ts.addTest("it ignores Invalid elements when calculating element's index", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      Invalid,
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+      Invalid,
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      Invalid
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+      {
+        name: "Label",
+        props: { id: "label2" },
+      },
+    ])
+
+    ' When
+    diffResult = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode)
+    labelToRender = diffResult.elementsToRender[0]
+
+    ' Then
+    return ts.assertEqual(labelToRender.index, 1)
   end function)
 
   ts.addTest("it marks an element to be removed and another to be rendered when they have the same name but different IDs", function (ts as Object) as String
@@ -256,7 +261,6 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "Label",
         props: { id: "label1" },
-        children: [],
       },
     ])
 
@@ -264,7 +268,6 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "Label",
         props: { id: "newLabel" },
-        children: [],
       },
     ])
 
@@ -286,7 +289,6 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "Label",
         props: { id: "label1" },
-        children: [],
       },
     ])
 
@@ -294,7 +296,6 @@ function TestSuite__KopytkoDiffUtility_Main()
       {
         name: "DaznButton",
         props: { id: "button1" },
-        children: [],
       },
     ])
 
@@ -317,7 +318,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { text: Invalid },
-        children: [],
       },
     ])
 
@@ -326,7 +326,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { text: "some text" },
-        children: [],
       },
     ])
 
@@ -347,7 +346,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1", text: Invalid },
         dynamicProps: { visible: false },
-        children: [],
       },
     ])
 
@@ -356,7 +354,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1", text: "some text" },
         dynamicProps: { visible: true },
-        children: [],
       },
     ])
 
@@ -377,7 +374,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { text: "some text" },
-        children: [],
       },
     ])
 
@@ -386,7 +382,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { text: Invalid },
-        children: [],
       },
     ])
 
@@ -407,7 +402,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { text: "some text" },
-        children: [],
       },
     ])
 
@@ -416,7 +410,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { text: "different text" },
-        children: [],
       },
     ])
 
@@ -437,7 +430,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1", customProp: [1, 2, 3] },
         dynamicProps: { customProp: [1, 2, 3] },
-        children: [],
       },
     ])
 
@@ -446,7 +438,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: [1, 2, 3, 4] },
-        children: [],
       },
     ])
 
@@ -467,7 +458,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: [1, 2, 3] },
-        children: [],
       },
     ])
 
@@ -476,7 +466,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: [4, 1, 3] },
-        children: [],
       },
     ])
 
@@ -497,7 +486,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: [[1, 2], [2, 4]] },
-        children: [],
       },
     ])
 
@@ -506,7 +494,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: [[2, 1], [6, 3]] },
-        children: [],
       },
     ])
 
@@ -527,7 +514,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: [{ id: 1 }, { id: 2 }] },
-        children: [],
       },
     ])
 
@@ -536,7 +522,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: [{ id: 4 }, { id: 9 }] },
-        children: [],
       },
     ])
 
@@ -557,7 +542,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: { key1: 1 } },
-        children: [],
       },
     ])
 
@@ -566,7 +550,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: { key1: 1, key2: 2 } },
-        children: [],
       },
     ])
 
@@ -587,7 +570,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: { id: 1 } },
-        children: [],
       },
     ])
 
@@ -596,7 +578,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: { id: 4 } },
-        children: [],
       },
     ])
 
@@ -617,7 +598,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: { arr: [1, 2, 3] } },
-        children: [],
       },
     ])
 
@@ -626,7 +606,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: { arr: [1, 2] } },
-        children: [],
       },
     ])
 
@@ -647,7 +626,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: { aa: { id: 1 } } },
-        children: [],
       },
     ])
 
@@ -656,7 +634,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: { aa: { id: 2 } } },
-        children: [],
       },
     ])
 
@@ -678,7 +655,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: currentNodeProp },
-        children: [],
       },
     ])
 
@@ -688,7 +664,6 @@ function TestSuite__KopytkoDiffUtility_Main()
         name: "Label",
         props: { id: "label1" },
         dynamicProps: { customProp: newNodeProp },
-        children: [],
       },
     ])
 

--- a/src/components/renderer/_tests/kopytkoDiffUtility/KopytkoDiffUtility_Main.test.brs
+++ b/src/components/renderer/_tests/kopytkoDiffUtility/KopytkoDiffUtility_Main.test.brs
@@ -311,6 +311,34 @@ function TestSuite__KopytkoDiffUtility_Main()
     return ts.assertEqual(diffResult, expectedResult, "The elements were not marked as expected")
   end function)
 
+  ts.addTest("it marks old element to be removed and new to be rendered when id remained the same but names are different", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "child1" },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "DaznButton",
+        props: { id: "child1" },
+      },
+    ])
+
+    ' When
+    diffResult = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode)
+    expectedResult = {
+      elementsToUpdate: {},
+      elementsToRender: [newVNode.children[0]],
+      elementsToRemove: ["child1"],
+    }
+
+    ' Then
+    return ts.assertEqual(diffResult, expectedResult, "The elements were not marked as expected")
+  end function)
+
   ts.addTest("it marks the element invalid props to be updated if they changed to a valid value", function (ts as Object) as String
     ' Given
     vNode = TestUtil_createRootElementWithChildren([


### PR DESCRIPTION
## What did you implement:

Fixed incorrect children insertion if children array contains Invalid elements

## How did you implement it:

By differently comparing current and new children arrays

## How can we verify it:

Unit tests

## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
