### PR TITLE
feat: introduced KopytkoRoot that makes integration easier

### DIFF
--- a/docs/renderer.md
+++ b/docs/renderer.md
@@ -314,8 +314,8 @@ end function
 See that all the function callback does is call `enqueueUpdate()`, which will cause Kopytko to run the `render` function
 again, this time getting the new value from `m.top.itemContent.labelText` and applying the change later on.
 
-### KopytkoRoot and initKopytkoRoot
-The example above can be also handled by importing the `KopytkoRoot.brs` in the root component and calling
+### initKopytkoRoot method
+The example above can be also handled by importing the `kopytkoRoot.brs` in the root component and calling
 `initKopytkoRoot` instead of `initKopytko`.
 
 `initKopytkoRoot` takes an array of dynamic props names as an input parameter, calls `initKopytko` with proper values

--- a/docs/renderer.md
+++ b/docs/renderer.md
@@ -119,83 +119,6 @@ component prop values instead of the state. In this example, text could be bound
 which is an interface field of the current component (a prop in Kopytko terminology), and the moment another parent
 component change the value of this field the same DOM update would happen again.
 
-### Force update and enqueue update methods
-The `forceUpdate` or `enqueueUpdate` methods should be used when you need to use data from a source other than the component state or props.
-For example, your Kopytko component is used as a list item component, so it doesn't have automatic observers on its props
-(because its parent is not a Kopytko component and therefore wasn't initialized via Kopytko mechanisms).
-You can imperatively tell Kopytko to force an update when you know the value changed, which will check the current
-DOM tree with the new one (containing the updated prop value now) and update the UI where needed. 
-The main difference between `forceUpdate` and `enqueueUpdate` is that the former is synchronous whilst the latter is asynchronous. In other words `enqueueUpdate` behaves the same way as `setState`, that's why it's safe to call it multiple times in a row and only a single DOM update will take place.
-
-You can check the example below for a practical use case of this method.
-
-```brightscript
-' Assuming the component extends KopytkoGroup
-sub init()
-  initKopytko({
-    width: m.top.width,
-    height: m.top.height,
-  })
-end sub
-
-sub componentDidMount()
-  m.top.observeFieldScoped("gridHasFocus", "enqueueUpdate")
-  m.top.observeFieldScoped("itemContent", "enqueueUpdate")
-end sub
-
-function render() as Object
-  return {
-    name: "Label",
-    props: {
-      id: "labelId",
-      text: m.top.itemContent.labelText,
-    },
-  }
-end function
-```
-
-See that all the function callback does is call `enqueueUpdate()`, which will cause Kopytko to run the `render` function
-again, this time getting the new value from `m.top.itemContent.labelText` and applying the change later on.
-
-### KopytkoRoot and initKopytkoRoot
-The example above can be also handled by importing the `KopytkoRoot.brs` in the root component and calling
-`initKopytkoRoot` instead of `initKopytko`.
-
-`initKopytkoRoot` takes an array of dynamic props names as an input parameter, calls `initKopytko` with proper values
-and automatically assigns observers.
-Whenever a dynamic prop is changed it calls `updateProps` function and this way it replicates the native Kopytko behavior.
-
-
-```brightscript
-sub init()
-  initKopytkoRoot(["height", "width", "itemContent"])
-end sub
-
-function render() as Object
-  return {
-    name: "Label",
-    props: {
-      id: "labelId",
-      text: m.top.itemContent.labelText,
-    },
-  }
-end function
-```
-
-### Rapidly updated fields
-
-To deal with fields of a component that are rapidly updated (e.g. `focusPercent` field of an item component assigned to a list/grid) it's not recommended to call `forceUpdate` or `enqueueUpdate` as it may generate a lot of CPU consumption. The proper way to tackle it would be to observe the field and update component manually.
-
-```brightscript
-sub componentDidMount()
-  m.top.observeFieldScoped("focusPercent", "_onFocusPercentChanged")
-end sub
-
-sub _onFocusPercentChanged(event as Object)
-  m.border.opacity= event.getData()
-end sub
-```
-
 ### Element selectors
 In the past we used to do something like `m.testLabel = m.top.findNode("testLabel")` in the `init` method of every component
 for every element we wanted to manipulate. With Kopytko there's no need for this process, all elements defined inside
@@ -351,6 +274,84 @@ function render() as Object
 end function
 ```
 
+## Using Kopytko components in the non-Kopytko environment"
+
+### Force update and enqueue update methods
+The `forceUpdate` or `enqueueUpdate` methods should be used when you need to use data from a source other than the component state or props.
+For example, your Kopytko component is used as a list item component, so it doesn't have automatic observers on its props
+(because its parent is not a Kopytko component and therefore wasn't initialized via Kopytko mechanisms).
+You can imperatively tell Kopytko to force an update when you know the value changed, which will check the current
+DOM tree with the new one (containing the updated prop value now) and update the UI where needed. 
+The main difference between `forceUpdate` and `enqueueUpdate` is that the former is synchronous whilst the latter is asynchronous. In other words `enqueueUpdate` behaves the same way as `setState`, that's why it's safe to call it multiple times in a row and only a single DOM update will take place.
+
+You can check the example below for a practical use case of this method.
+
+```brightscript
+' Assuming the component extends KopytkoGroup
+sub init()
+  initKopytko({
+    width: m.top.width,
+    height: m.top.height,
+  })
+end sub
+
+sub componentDidMount()
+  m.top.observeFieldScoped("gridHasFocus", "enqueueUpdate")
+  m.top.observeFieldScoped("itemContent", "enqueueUpdate")
+end sub
+
+function render() as Object
+  return {
+    name: "Label",
+    props: {
+      id: "labelId",
+      text: m.top.itemContent.labelText,
+    },
+  }
+end function
+```
+
+See that all the function callback does is call `enqueueUpdate()`, which will cause Kopytko to run the `render` function
+again, this time getting the new value from `m.top.itemContent.labelText` and applying the change later on.
+
+### KopytkoRoot and initKopytkoRoot
+The example above can be also handled by importing the `KopytkoRoot.brs` in the root component and calling
+`initKopytkoRoot` instead of `initKopytko`.
+
+`initKopytkoRoot` takes an array of dynamic props names as an input parameter, calls `initKopytko` with proper values
+and automatically assigns observers.
+Whenever a dynamic prop is changed it calls `updateProps` function and this way it replicates the native Kopytko behavior.
+
+
+```brightscript
+sub init()
+  initKopytkoRoot(["height", "width", "itemContent"])
+end sub
+
+function render() as Object
+  return {
+    name: "Label",
+    props: {
+      id: "labelId",
+      text: m.top.itemContent.labelText,
+    },
+  }
+end function
+```
+
+### Rapidly updated fields
+
+To deal with fields of a component that are rapidly updated (e.g. `focusPercent` field of an item component assigned to a list/grid) it's not recommended to call `forceUpdate` or `enqueueUpdate` as it may generate a lot of CPU consumption. The proper way to tackle it would be to observe the field and update component manually.
+
+```brightscript
+sub componentDidMount()
+  m.top.observeFieldScoped("focusPercent", "_onFocusPercentChanged")
+end sub
+
+sub _onFocusPercentChanged(event as Object)
+  m.border.opacity= event.getData()
+end sub
+```
 
 ## Tests
 You can easily test Kopytko components using the [Kopytko Unit Testing Framework](https://github.com/getndazn/kopytko-unit-testing-framework).

--- a/docs/renderer.md
+++ b/docs/renderer.md
@@ -157,6 +157,33 @@ end function
 See that all the function callback does is call `enqueueUpdate()`, which will cause Kopytko to run the `render` function
 again, this time getting the new value from `m.top.itemContent.labelText` and applying the change later on.
 
+### KopytkoRoot and initKopytkoRoot
+The example above can be also handled by importing the `KopytkoRoot.brs` in the root component and calling
+`initKopytkoRoot` instead of `initKopytko`.
+
+`initKopytkoRoot` takes an array of dynamic props names as an input parameter, calls `initKopytko` with proper values
+and automatically assigns observers.
+Whenever a dynamic prop is changed it calls `updateProps` function and this way it replicates the native Kopytko behavior.
+
+
+```brightscript
+sub init()
+  initKopytkoRoot(["height", "width", "itemContent"])
+end sub
+
+function render() as Object
+  return {
+    name: "Label",
+    props: {
+      id: "labelId",
+      text: m.top.itemContent.labelText,
+    },
+  }
+end function
+```
+
+### Rapidly updated fields
+
 To deal with fields of a component that are rapidly updated (e.g. `focusPercent` field of an item component assigned to a list/grid) it's not recommended to call `forceUpdate` or `enqueueUpdate` as it may generate a lot of CPU consumption. The proper way to tackle it would be to observe the field and update component manually.
 
 ```brightscript

--- a/src/components/renderer/_tests/kopytkoRoot/KopytkoRootTestExample.component.brs
+++ b/src/components/renderer/_tests/kopytkoRoot/KopytkoRootTestExample.component.brs
@@ -1,0 +1,33 @@
+' @import /components/_mocks/Mock.brs from @dazn/kopytko-unit-testing-framework
+' @import /components/renderer/KopytkoRoot.brs
+sub init()
+  m.__mocks = {
+    initKopytko: invalid,
+    updateProps: invalid,
+  }
+
+  m._mock = Mock({
+    testComponent: m,
+    name: "KopytkoRoot",
+    methods: {
+      initKopytko: sub (dynamicProps as Object)
+        m.initKopytkoMock("initKopytko", { dynamicProps: dynamicProps })
+      end sub,
+      updateProps: sub (props as Object)
+        m.updatePropsMock("updateProps", { props: props })
+      end sub,
+    },
+  })
+end sub
+
+sub initKopytko(dynamicProps as Object)
+  m._mock.initKopytko(dynamicProps)
+end sub
+
+sub updateProps(props as Object)
+  m._mock.updateProps(props)
+end sub
+
+function getMocks() as Object
+  return m.__mocks
+end function

--- a/src/components/renderer/_tests/kopytkoRoot/KopytkoRootTestExample.component.brs
+++ b/src/components/renderer/_tests/kopytkoRoot/KopytkoRootTestExample.component.brs
@@ -1,5 +1,5 @@
 ' @import /components/_mocks/Mock.brs from @dazn/kopytko-unit-testing-framework
-' @import /components/renderer/KopytkoRoot.brs
+' @import /components/renderer/kopytkoRoot.brs
 sub init()
   m.__mocks = {
     initKopytko: invalid,
@@ -8,7 +8,7 @@ sub init()
 
   m._mock = Mock({
     testComponent: m,
-    name: "KopytkoRoot",
+    name: "kopytkoRoot",
     methods: {
       initKopytko: sub (dynamicProps as Object)
         m.initKopytkoMock("initKopytko", { dynamicProps: dynamicProps })

--- a/src/components/renderer/_tests/kopytkoRoot/KopytkoRootTestExample.component.brs
+++ b/src/components/renderer/_tests/kopytkoRoot/KopytkoRootTestExample.component.brs
@@ -2,8 +2,8 @@
 ' @import /components/renderer/kopytkoRoot.brs
 sub init()
   m.__mocks = {
-    initKopytko: invalid,
-    updateProps: invalid,
+    initKopytko: Invalid,
+    updateProps: Invalid,
   }
 
   m._mock = Mock({

--- a/src/components/renderer/_tests/kopytkoRoot/KopytkoRootTestExample.component.xml
+++ b/src/components/renderer/_tests/kopytkoRoot/KopytkoRootTestExample.component.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<component name="KopytkoRootTestExample" extends="KopytkoGroup">
+  <interface>
+    <field id="prop1" type="string" />
+    <field id="prop2" type="string" />
+
+    <function name="initKopytkoRoot" />
+    <function name="destroyKopytkoRoot" />
+
+    <function name="getMocks" />
+  </interface>
+
+  <script type="text/brightscript" uri="KopytkoRootTestExample.component.brs" />
+</component>

--- a/src/components/renderer/_tests/kopytkoRoot/kopytkoRoot.test.brs
+++ b/src/components/renderer/_tests/kopytkoRoot/kopytkoRoot.test.brs
@@ -1,0 +1,87 @@
+' @import /components/_mocks/Mock.brs from @dazn/kopytko-unit-testing-framework
+' @import /components/_testUtils/fakeClock.brs from @dazn/kopytko-unit-testing-framework
+' @import /components/KopytkoFrameworkTestSuite.brs from @dazn/kopytko-unit-testing-framework
+' @mock /components/rokuComponents/Timer.brs from @dazn/kopytko-utils
+
+function TestSuite__KopytkoRoot()
+  ts = KopytkoFrameworkTestSuite()
+  ts.name = "KopytkoRoot"
+
+  ts.setBeforeEach(sub (ts as Object)
+    m.__mocks = {}
+  end sub)
+
+  ts.addTest("initKopytkoRoot initializes Kopytko with given dynamic props", function (ts as Object) as String
+    ' Given
+    dynamicProps = ["prop1", "prop2"]
+    root = CreateObject("roSGNode", "KopytkoRootTestExample")
+    root.prop1 = "Prop 1"
+    root.prop2 = "Prop 2"
+
+    ' When
+    root.callFunc("initKopytkoRoot", dynamicProps)
+
+    ' Then
+    kopytkoMock = root.callFunc("getMocks").kopytkoRoot
+    initKopytkoCalls = kopytkoMock.initKopytko.calls
+    if (initKopytkoCalls.count() = 0)
+      return ts.fail("Kopytko was not initialized")
+    end if
+    expectedDynamicProps = {
+      prop1: root.prop1,
+      prop2: root.prop2,
+    }
+
+    return ts.assertEqual(expectedDynamicProps, initKopytkoCalls[0].params.dynamicProps, "Kopytko based element was initialized with invalid props")
+  end function)
+
+  ts.addTest("initialized Kopytko root calls updateProps on dynamic prop change", function (ts as Object) as String
+    ' Given
+    root = CreateObject("roSGNode", "KopytkoRootTestExample")
+    root.callFunc("initKopytkoRoot", ["prop1", "prop2"])
+
+    ' When
+    root.prop1 = "New prop1"
+
+    ' Then
+    kopytkoMock = root.callFunc("getMocks").kopytkoRoot
+    updatePropsCalls = kopytkoMock.updateProps.calls
+    if (updatePropsCalls.count() = 0)
+      return ts.fail("updateProps was not called for changed dynamic prop")
+    end if
+    expectedProps = { prop1: root.prop1 }
+
+    return ts.assertEqual(expectedProps, updatePropsCalls[0].params.props, "Kopytko based element was initialized with invalid props")
+  end function)
+
+  ts.addTest("initialized Kopytko root does not call updateProps on static prop change", function (ts as Object) as String
+    ' Given
+    root = CreateObject("roSGNode", "KopytkoRootTestExample")
+    root.callFunc("initKopytkoRoot", ["prop1"])
+
+    ' When
+    root.prop2 = "New prop2"
+
+    ' Then
+    m.__mocks = root.callFunc("getMocks")
+
+    return ts.assertMethodWasNotCalled("kopytkoRoot.updateProps")
+  end function)
+
+  ts.addTest("destroyKopytkoRoot unobserves registered observers for dynamic props", function (ts as Object) as String
+    ' Given
+    root = CreateObject("roSGNode", "KopytkoRootTestExample")
+    root.callFunc("initKopytkoRoot", ["prop1"])
+
+    ' When
+    root.callFunc("destroyKopytkoRoot")
+    root.prop1 = "New prop1"
+
+    ' Then
+    m.__mocks = root.callFunc("getMocks")
+
+    return ts.assertMethodWasNotCalled("kopytkoRoot.updateProps")
+  end function)
+
+  return ts
+end function

--- a/src/components/renderer/_tests/kopytkoRoot/kopytkoRoot.test.brs
+++ b/src/components/renderer/_tests/kopytkoRoot/kopytkoRoot.test.brs
@@ -3,9 +3,9 @@
 ' @import /components/KopytkoFrameworkTestSuite.brs from @dazn/kopytko-unit-testing-framework
 ' @mock /components/rokuComponents/Timer.brs from @dazn/kopytko-utils
 
-function TestSuite__KopytkoRoot()
+function TestSuite__kopytkoRoot()
   ts = KopytkoFrameworkTestSuite()
-  ts.name = "KopytkoRoot"
+  ts.name = "kopytkoRoot"
 
   ts.setBeforeEach(sub (ts as Object)
     m.__mocks = {}

--- a/src/components/renderer/kopytkoRoot.brs
+++ b/src/components/renderer/kopytkoRoot.brs
@@ -2,7 +2,7 @@ sub initKopytkoRoot(dynamicProps as Object)
   m._dynamicProps = dynamicProps
 
   for each prop in dynamicProps
-    m.top.observeFieldScoped(prop, "KopytkoRoot_dynamicPropChanged")
+    m.top.observeFieldScoped(prop, "kopytkoRoot_dynamicPropChanged")
   end for
 
   dynamicPropsValues = {}
@@ -21,7 +21,7 @@ sub destroyKopytkoRoot()
   m._dynamicProps = invalid
 end sub
 
-sub KopytkoRoot_dynamicPropChanged(event as Object)
+sub kopytkoRoot_dynamicPropChanged(event as Object)
   props = {}
   props[event.getField()] = event.getData()
   updateProps(props)

--- a/src/components/renderer/kopytkoRoot.brs
+++ b/src/components/renderer/kopytkoRoot.brs
@@ -18,7 +18,7 @@ sub destroyKopytkoRoot()
     m.top.unobserveFieldScoped(prop)
   end for
 
-  m._dynamicProps = invalid
+  m._dynamicProps = Invalid
 end sub
 
 sub kopytkoRoot_dynamicPropChanged(event as Object)

--- a/src/components/renderer/kopytkoRoot.brs
+++ b/src/components/renderer/kopytkoRoot.brs
@@ -1,0 +1,18 @@
+sub initKopytkoRoot(dynamicProps as Object)
+  for each prop in dynamicProps
+    m.top.observeFieldScoped(prop, "KopytkoRoot_dynamicPropChanged")
+  end for
+
+  dynamicPropsValues = {}
+  for each prop in dynamicProps
+    dynamicPropsValues[prop] = m.top[prop]
+  end for
+
+  initKopytko(dynamicPropsValues)
+end sub
+
+sub KopytkoRoot_dynamicPropChanged(event as Object)
+  props = {}
+  props[event.getField()] = event.getData()
+  updateProps(props)
+end sub

--- a/src/components/renderer/kopytkoRoot.brs
+++ b/src/components/renderer/kopytkoRoot.brs
@@ -1,4 +1,6 @@
 sub initKopytkoRoot(dynamicProps as Object)
+  m._dynamicProps = dynamicProps
+
   for each prop in dynamicProps
     m.top.observeFieldScoped(prop, "KopytkoRoot_dynamicPropChanged")
   end for
@@ -9,6 +11,14 @@ sub initKopytkoRoot(dynamicProps as Object)
   end for
 
   initKopytko(dynamicPropsValues)
+end sub
+
+sub destroyKopytkoRoot()
+  for each prop in m._dynamicProps
+    m.top.unobserveFieldScoped(prop)
+  end for
+
+  m._dynamicProps = invalid
 end sub
 
 sub KopytkoRoot_dynamicPropChanged(event as Object)


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

`KopytkoRoot.brs` with `initKopytkoRoot` that makes easier integration with Kopytko, ie. when we want Kopytko to be used in a non-kopytko parent component.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

`initKopytkoRoot` receives a list of dynamic props, observes them, and initializes component with current values of dynamic props. 
Dynamic props observer calls `updateProps` for the changed prop. That could be in future improved to enqueue such changes.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

There is an example in the readme. This way it can be applied to the item component used by the RowList (or other ArrayGrid components). Thanks to this there is no need of adding observers manually and `componentDidUpdate` receives correct `prevProps`. Without calling `updateProps` on prop change `componentDidUpdate` gets always initial values in `prevProps`.

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [X] Write documentation (if required)
- [X] Fix linting errors
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
