### PR TITLE
fix: not using findNode when removing component's children

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@dazn/kopytko-framework",
-      "version": "1.3.0",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "@dazn/kopytko-utils": "^2.2.2"

--- a/src/components/renderer/KopytkoDOM.brs
+++ b/src/components/renderer/KopytkoDOM.brs
@@ -3,6 +3,8 @@ function KopytkoDOM() as Object
 
   prototype.componentsMapping = {}
 
+  prototype._renderedElements = {}
+
   ' Renders an element based on the given virtual node
   ' @param {Object} vNode - The virtual node
   ' @param {Object} parentElement - The parent element where the element will be rendered
@@ -44,6 +46,8 @@ function KopytkoDOM() as Object
     else
       parentElement.appendChild(element)
     end if
+
+    m._renderedElements[element.id] = element
 
     m._setElementSelector(element)
   end sub
@@ -94,7 +98,7 @@ function KopytkoDOM() as Object
     rootElement = m._getRootComponent()
 
     for each elementId in elements
-      element = rootElement.top.findNode(elementId)
+      element = m._renderedElements[elementId]
 
       if (element <> Invalid)
         m._destroyKopytkoElement(element)
@@ -106,6 +110,7 @@ function KopytkoDOM() as Object
       end if
 
       rootElement.delete(elementId)
+      m._renderedElements.delete(elementId)
     end for
   end sub
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

There is an issue with the renderer that removes the component from its parent when the child of the component has the same `id` and has been conditionally removed.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

To fix the issue a map of the rendered elements was introduced and instead of using the native `findNode` function the map is checked for the existence of the element.
`findNode` includes also the component on which we call it, not only children of it:

From the [docs](https://developer.roku.com/en-gb/docs/references/brightscript/interfaces/ifsgnodedict.md#findnodename-as-string-as-object):
```
Returns the node that is a descendant of the nearest component ancestor of the subject node (possibly the subject node itself) and whose id field is set to name.
```


## How can we verify it:

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

All should work as before (no regression), but additionally, it should be possible to have the same id for the parent and child components.

E.g
Template 1:
```brightscript
return {
    name: "Component1"
    props: { id: "comp1" }
}
```

Template 2 of `Component1`:
```brightscript
if condition
    return {
        name: "Component2"
        props: { id: "comp1" }
    }
end if

return invalid
```

## Todos:

- [X] Write documentation (if required)
- [X] Fix linting errors
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
