### PR TITLE
feat: store's subscribe callback accepts a context

### DIFF
--- a/docs/store.md
+++ b/docs/store.md
@@ -8,8 +8,8 @@ Its public methods:
 - `consume(key as String)` - return a stored value from given key and removes it from the store
 - `remove(key as String)` - removes value and key from the store
 - `setFields(newSet as Object)` - similar to `set()`, but allows setting multiple values at once
-- `subscribe(key as String, callback as Function)` - subscribes to value changes from given key and calls callback function on every change
+- `subscribe(key as String, callback as Function, context = Invalid as Object)` - subscribes to value changes from a given key and calls the callback function on every change, optionally the context could be provided
 - `unsubscribe(key as String, callback as Function)` - unsubscribes specific callback of the key
-- `subscribeOnce(key as String, callback as Function)` - similar to `subscribe` but it automatically unsubscribes after the first callback run
+- `subscribeOnce(key as String, callback as Function, context = Invalid as Object)` - similar to `subscribe` but it automatically unsubscribes after the first callback run
 - `updateNode(key as String, value as Dynamic)` - updates fields (passed as `value` object) of the stored node from given key
 - `updateAA(key as String, updatedData as Object)` - updates fields of the stored AA from given key

--- a/src/components/store/Store.facade.brs
+++ b/src/components/store/Store.facade.brs
@@ -93,14 +93,14 @@ function StoreFacade() as Object
     end for
   end sub
 
-  prototype.subscribeOnce = sub (key as String, callback as Function)
+  prototype.subscribeOnce = sub (key as String, callback as Function, context = Invalid as Object)
     m._handleSubscriber(key)
-    m._subscriptions[m._getRandomizedKey(key)] = { key: key, callback: [callback], once: true }
+    m._subscriptions[m._getRandomizedKey(key)] = { key: key, callback: [callback], context: context, once: true }
   end sub
 
-  prototype.subscribe = sub (key as String, callback as Function)
+  prototype.subscribe = sub (key as String, callback as Function, context = Invalid as Object)
     m._handleSubscriber(key)
-    m._subscriptions[m._getRandomizedKey(key)] = { key: key, callback: [callback], once: false }
+    m._subscriptions[m._getRandomizedKey(key)] = { key: key, callback: [callback], context: context, once: false }
   end sub
 
   prototype.unsubscribe = sub (key as String, callback as Function)
@@ -144,7 +144,11 @@ function StoreFacade() as Object
       listener = m._subscriptions[subscriptionKey]
 
       if (listener <> Invalid AND listener.key = key)
-        listener.callback[0](value)
+        if (listener.context = Invalid)
+          listener.callback[0](value)
+        else
+          listener.callback[0](value, listener.context)
+        end if
 
         if (listener.once)
           m._subscriptions.delete(subscriptionKey)

--- a/src/components/store/_tests/StoreFacade.test.brs
+++ b/src/components/store/_tests/StoreFacade.test.brs
@@ -1,10 +1,11 @@
 ' @import /components/KopytkoFrameworkTestSuite.brs from @dazn/kopytko-unit-testing-framework
 ' @import /components/getType.brs from @dazn/kopytko-utils
 ' @mock /components/utils/KopytkoGlobalNode.brs
+
 function StoreFacadeTestSuite() as Object
   ts = KopytkoFrameworkTestSuite()
 
-  ts.setBeforeEach(sub (ts as Object)
+  beforeEach(sub (_ts as Object)
     m._store = Invalid
     m.__spy = {
       subscriber: {
@@ -29,4 +30,9 @@ end sub
 sub otherSubscriber(arg1 as Dynamic)
   m.__spy.otherSubscriber.lastArg = arg1
   m.__spy.otherSubscriber.calledTimes += 1
+end sub
+
+sub contextSubscriber(arg1 as Dynamic, context as Object)
+  context.__spy.contextSubscriber.lastArg = arg1
+  context.__spy.contextSubscriber.calledTimes += 1
 end sub

--- a/src/components/store/_tests/StoreFacade_subscribe.test.brs
+++ b/src/components/store/_tests/StoreFacade_subscribe.test.brs
@@ -2,7 +2,7 @@ function TestSuite__StoreFacade_subscribe() as Object
   ts = StoreFacadeTestSuite()
   ts.name = "StoreFacade_subscribe"
 
-  ts.addTest("should add 1 subscriber", function (ts as Object) as String
+  it("should add 1 subscriber", function (_ts as Object) as String
     ' Given
     expectedResult = 1
     store = StoreFacade()
@@ -11,12 +11,11 @@ function TestSuite__StoreFacade_subscribe() as Object
     store.subscribe("title", subscriber)
 
     ' Then
-    return ts.assertEqual(store._subscriptions.count(), expectedResult)
+    return expect(store._subscriptions.count()).toBe(1)
   end function)
 
-  ts.addTest("should add 2 subscribers", function (ts as Object) as String
+  it("should add 2 subscribers", function (_ts as Object) as String
     ' Given
-    expectedResult = 2
     store = StoreFacade()
 
     ' When
@@ -24,23 +23,35 @@ function TestSuite__StoreFacade_subscribe() as Object
     store.subscribe("test", otherSubscriber)
 
     ' Then
-    return ts.assertEqual(store._subscriptions.count(), expectedResult)
+    return expect(store._subscriptions.count()).toBe(2)
   end function)
 
-  ts.addTest("should call callback in sequence", function (ts as Object) as String
+  it("should call callback in sequence", function (_ts as Object) as String
     ' Given
-    expectedResult = 4
     store = StoreFacade()
 
     ' When
     store.subscribe("title", subscriber)
-    store.set("title", { data: "2" })
+    store.set("title", "someTitle")
     store.set("title", Invalid)
-    store.set("title", { data: "3" })
-    store.set("title", { otherData: 1 })
+    store.set("title", "someOtherTitle")
 
     ' Then
-    return ts.assertEqual(m.__spy.subscriber.calledTimes, expectedResult)
+    return expect(m.__spy.subscriber.calledTimes).toBe(3)
+  end function)
+
+  it("should call callback with the given context when it is provided", function (_ts as Object) as String
+    ' Given
+    context = { __spy: { contextSubscriber: { calledTimes: 0 } } }
+    store = StoreFacade()
+
+    ' When
+    store.subscribe("title", contextSubscriber, context)
+    store.set("title", "someTitle")
+    store.set("title", Invalid)
+
+    ' Then
+    return expect(context.__spy.contextSubscriber.calledTimes).toBe(2)
   end function)
 
   return ts

--- a/src/components/store/_tests/StoreFacade_subscribeOnce.test.brs
+++ b/src/components/store/_tests/StoreFacade_subscribeOnce.test.brs
@@ -2,7 +2,7 @@ function TestSuite__StoreFacade_subscribeOnce() as Object
   ts = StoreFacadeTestSuite()
   ts.name = "StoreFacade_subscribeOnce"
 
-  ts.addTest("should add 1 subscriber", function (ts as Object) as String
+  it("should add 1 subscriber", function (_ts as Object) as String
     ' Given
     expectedResult = 1
     store = StoreFacade()
@@ -11,10 +11,10 @@ function TestSuite__StoreFacade_subscribeOnce() as Object
     store.subscribeOnce("title", subscriber)
 
     ' Then
-    return ts.assertEqual(store._subscriptions.count(), expectedResult)
+    return expect(store._subscriptions.count()).toBe(1)
   end function)
 
-  ts.addTest("should add 2 subscribers", function (ts as Object) as String
+  it("should add 2 subscribers", function (_ts as Object) as String
     ' Given
     expectedResult = 2
     store = StoreFacade()
@@ -24,7 +24,33 @@ function TestSuite__StoreFacade_subscribeOnce() as Object
     store.subscribeOnce("test", otherSubscriber)
 
     ' Then
-    return ts.assertEqual(store._subscriptions.count(), expectedResult)
+    return expect(store._subscriptions.count()).toBe(2)
+  end function)
+
+  it("should call callback only once", function (_ts as Object) as String
+    ' Given
+    store = StoreFacade()
+
+    ' When
+    store.subscribeOnce("title", subscriber)
+    store.set("title", "someTitle")
+    store.set("title", Invalid)
+
+    ' Then
+    return expect(m.__spy.subscriber.calledTimes).toBe(1)
+  end function)
+
+  it("should call callback with the given context when it is provided", function (_ts as Object) as String
+    ' Given
+    context = { __spy: { contextSubscriber: { calledTimes: 0 } } }
+    store = StoreFacade()
+
+    ' When
+    store.subscribeOnce("title", contextSubscriber, context)
+    store.set("title", "someTitle")
+
+    ' Then
+    return expect(context.__spy.contextSubscriber.calledTimes).toBe(1)
   end function)
 
   return ts


### PR DESCRIPTION
## What did you implement:

Closes [#18](https://github.com/getndazn/kopytko-framework/issues/18)

The Store's subscription callback receives now passed context.

## How did you implement it:

`subscribe` and `subscribeOnce` methods have now an additional optional argument - context

## How can we verify it:

There are new unit tests:

```brs
  it("should call callback with the given context when it is provided", function (_ts as Object) as String
    ' Given
    context = { __spy: { contextSubscriber: { calledTimes: 0 } } }
    store = StoreFacade()

    ' When
    store.subscribe("title", contextSubscriber, context)
    store.set("title", "someTitle")
    store.set("title", Invalid)

    ' Then
    return expect(context.__spy.contextSubscriber.calledTimes).toBe(2)
  end function)
```

```brs
  it("should call callback with the given context when it is provided", function (_ts as Object) as String
    ' Given
    context = { __spy: { contextSubscriber: { calledTimes: 0 } } }
    store = StoreFacade()

    ' When
    store.subscribeOnce("title", contextSubscriber, context)
    store.set("title", "someTitle")

    ' Then
    return expect(context.__spy.contextSubscriber.calledTimes).toBe(1)
  end function)
```

Where

```brs
sub contextSubscriber(arg1 as Dynamic, context as Object)
  context.__spy.contextSubscriber.lastArg = arg1
  context.__spy.contextSubscriber.calledTimes += 1
end sub
```

## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
