### PR TITLE
fix: clearing EventBus registered events on component destroy

### DIFF
--- a/src/components/eventBus/EventBus.facade.brs
+++ b/src/components/eventBus/EventBus.facade.brs
@@ -52,7 +52,7 @@ function EventBusFacade() as Object
       return
     end if
 
-    m._eventsMap[eventName] = m._arrayUtils.filter(callbacks, function(callback as object, handlerToRemove as function) as boolean
+    m._eventsMap[eventName] = m._arrayUtils.filter(callbacks, function (callback as Object, handlerToRemove as Function) as Boolean
       return (callback.handler <> handlerToRemove)
     end function, handlerToRemove)
   end sub

--- a/src/components/renderer/Kopytko.brs
+++ b/src/components/renderer/Kopytko.brs
@@ -34,10 +34,8 @@ sub destroyKopytko(data = {} as Object)
 
   componentWillUnmount()
 
-  if (m.global.eventBus <> Invalid)
-    for each event in m.global.eventBus.getFields()
-      m.global.eventBus.unobserveFieldScoped(event)
-    end for
+  if (m["$$eventBus"] <> Invalid)
+    m["$$eventBus"].clear()
   end if
 
   m.state = {}


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Currently, when the Kopytko component is destroyed, listeners are detached from the globally stored EventBus node. However, data is not removed from the private fields of the `EventBusFacade`. It may lead to memory leaks.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

To avoid memory leaks, I introduced a new `clear` function in the `EventBusFacade` which is called when the Kopytko component is destroyed. The function removed all data related to the registered events within the scope of the destroyed component. 

I also renamed the private `_eventBus` field to `$$eventBus` to make it more unique and distinguish it from the regular private field. This is for ensuring unambiguity when checking for `EventBusFacade` instance existence in the `destroyKopytko` function and avoid potential naming collisions.

## How can we verify it:

There should be no regression when it comes to the EventBus.

No memory leaks on component destroy.

Before changes, memory leaks may occur when an event is registered with the context. For example create `APrototype` inside a Kopytko component, then destroy the component. Verify memory leaks.
```brightscript
function APrototype(componentNode as Object) as Object
    _constructor = function(m as Object) as Object
        m._eventBus.on("anEvent", m._aHandler, m)

        return m
    end function


    prototype = {
        _componentNode: componentNode
        _eventBus: EventBusFacade()

        aHandler: sub(payload as Object)
        end sub
    }

    return _constructor(prototype)
end function

```


<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [X] Write documentation (if required)
- [X] Fix linting errors
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
