### PR TITLE
fix: event bus storing last payload of each event

### DIFF
--- a/src/components/eventBus/EventBus.xml
+++ b/src/components/eventBus/EventBus.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<component name="EventBus" extends="Node">
+  <interface>
+    <field id="$$payload" type="assocarray" /> <!-- prefixed with $$ to avoid name collision with dynamically added events -->
+  </interface>
+</component>

--- a/src/components/utils/_mocks/KopytkoGlobalNode.mock.brs
+++ b/src/components/utils/_mocks/KopytkoGlobalNode.mock.brs
@@ -5,9 +5,12 @@
 
 ' @returns {Mock}
 function KopytkoGlobalNode() as Object
+  eventBusNode = createNode()
+  eventBusNode.addField("$$payload", "assocarray", false)
+
   fields = {
     cache: createNode(),
-    eventBus: createNode(),
+    eventBus: eventBusNode,
     router: createNode(),
     store: createNode(),
     theme: createNode(),


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fixed memory leaks from the EventBus node which was storing the last payload of each event

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
Changed event-specific fields in the EventBus node to boolean instead of AA.
Added a dedicated `$$payload` field to the EventBus node which stores the payload of the currently being triggered event. 
The field is cleared after dispatching an event.

## How can we verify it:

Basically, no regression when it comes to the app behavior.

Additionally, it can be verified by [ECP](https://developer.roku.com/en-gb/docs/developer-program/dev-tools/external-control-api.md#external-control-service-commands) (`query/sgnodes/roots`) if some nodes were leaking before changes and are not leaking anymore with these changes.

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [X] Write documentation (if required)
- [X] Fix linting errors
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
