### PR TITLE
fix: attaching observer in kopytkoRoot

### DIFF
--- a/src/components/renderer/kopytkoRoot.brs
+++ b/src/components/renderer/kopytkoRoot.brs
@@ -1,16 +1,16 @@
 sub initKopytkoRoot(dynamicProps as Object)
   m._dynamicProps = dynamicProps
 
-  for each prop in dynamicProps
-    m.top.observeFieldScoped(prop, "kopytkoRoot_dynamicPropChanged")
-  end for
-
   dynamicPropsValues = {}
   for each prop in dynamicProps
     dynamicPropsValues[prop] = m.top[prop]
   end for
 
   initKopytko(dynamicPropsValues)
+
+  for each prop in dynamicProps
+    m.top.observeFieldScoped(prop, "kopytkoRoot_dynamicPropChanged")
+  end for
 end sub
 
 sub destroyKopytkoRoot()


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

`initKopytkoRoot` function attaches observers for dynamic props before calling `initKopytko`, thus it is possible that field change callback `kopytkoRoot_dynamicPropChanged` is called before initialization is completed. And this is because `initKopytko` updates the component with provided dynamic props by calling `m.top.update(dynamicProps)`

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Moved attaching observers after the `initKopytko` call
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [X] Write documentation (if required)
- [X] Fix linting errors
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
