### PR TITLE
fix: HttpResponse.rawData accepts only AssocArray

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -52,7 +52,7 @@ end function
 
 function parseResponse(response as Object) as Object
   user = CreateObject("roSGNode", "User") ' example custom roSGNode extending Node
-  user.status = response.rawData.status
+  user.status = response.raw.data.status
 
   return user
 end function

--- a/src/components/http/HttpResponse.brs
+++ b/src/components/http/HttpResponse.brs
@@ -9,6 +9,7 @@
 ' @param {String} responseData.failureReason
 ' @param {Object} responseData.headers
 ' @param {Integer} responseData.httpStatusCode
+' @param {Object} responseData.rawData
 ' @param {Object} responseData.requestOptions
 ' @param {Integer} [responseData.time]
 function HttpResponse(responseData as Object) as Object
@@ -25,7 +26,7 @@ function HttpResponse(responseData as Object) as Object
   prototype._failureReason = getProperty(responseData, "failureReason", "OK")
   prototype._headers = getProperty(responseData, "headers", {})
   prototype._httpStatusCode = getProperty(responseData, "httpStatusCode", -1)
-  prototype._rawData = getProperty(responseData, "rawData", {})
+  prototype._rawData = getProperty(responseData, "rawData")
   prototype._requestOptions = responseData.requestOptions
   prototype._time = DateTime().asSeconds()
 
@@ -44,6 +45,7 @@ function HttpResponse(responseData as Object) as Object
       isReusable: m.isReusable(),
       isSuccess: m._isSuccess(),
       maxAge: m.getMaxAge(),
+      raw: { data: m._rawData },
       rawData: m._rawData,
       requestOptions: m._requestOptions,
     })

--- a/src/components/http/HttpResponse.model.xml
+++ b/src/components/http/HttpResponse.model.xml
@@ -9,7 +9,8 @@
     <field id="isReusable" type="boolean" />
     <field id="isSuccess" type="boolean" />
     <field id="maxAge" type="integer" />
-    <field id="rawData" type="assocarray" />
+    <field id="raw" type="assocarray" />
+    <field id="rawData" type="assocarray" /> <!-- @deprecated - raw field contains data key with rawData value now - raw = { data: <rawData value>} -->
     <field id="requestOptions" type="assocarray" />
   </interface>
 </component>

--- a/src/components/http/_tests/HttpResponse_Main.test.brs
+++ b/src/components/http/_tests/HttpResponse_Main.test.brs
@@ -18,6 +18,7 @@ function TestSuite__HttpResponse_Main() as Object
       headers: props.headers,
       id: props.id,
       isSuccess: true,
+      raw: { data: props.rawData },
       rawData: props.rawData,
     })
 
@@ -43,6 +44,7 @@ function TestSuite__HttpResponse_Main() as Object
       httpStatusCode: props.httpStatusCode,
       failureReason: props.failureReason,
       headers: props.headers,
+      raw: { data: props.rawData },
       rawData: props.rawData,
     })
 

--- a/src/components/http/request/_mocks/Request.mock.xml
+++ b/src/components/http/request/_mocks/Request.mock.xml
@@ -6,6 +6,8 @@
     <field id="data" type="assocarray" />
     <field id="options" type="assocarray" />
     <field id="result" type="node" />
+    <!-- Task fields -->
+    <field id="control" type="string" />
   </interface>
 
   <script type="text/brightscript" uri="Request.mock.brs" />

--- a/src/components/router/_tests/Router.test.brs
+++ b/src/components/router/_tests/Router.test.brs
@@ -244,7 +244,6 @@ end function
 
 sub RouterTestSuite__TearDown(ts as Object)
   m.top.activatedRoute = CreateObject("roSGNode", "ActivatedRoute")
-  m.top.activatedPath = ""
   m.top.url = "/"
 
   m._history = []


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

HttpResponse has now a `raw` field alongside `rawData`, which is an Associative Array with a `data` field that could have any type now.

## Fixes:

https://github.com/getndazn/kopytko-framework/issues/53

## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
