### PR TITLE
fix: wrong previousRoute after back journey

### DIFF
--- a/src/components/router/ActivatedRoute.xml
+++ b/src/components/router/ActivatedRoute.xml
@@ -9,6 +9,7 @@
     <field id="renderedUrl" type="string" />
     <field id="routeConfig" type="assocarray" />
     <field id="shouldSkip" type="boolean" />
+    <field id="skipInHistory" type="boolean" />
     <field id="virtualPath" type="string" />
   </interface>
 </component>

--- a/src/components/router/Router.brs
+++ b/src/components/router/Router.brs
@@ -1,8 +1,8 @@
 ' @import /components/buildUrl.brs from @dazn/kopytko-utils
 ' @import /components/getProperty.brs from @dazn/kopytko-utils
 ' @import /components/NodeUtils.brs from @dazn/kopytko-utils
-' @import /components/ternary.brs from @dazn/kopytko-utils
 ' @import /components/utils/KopytkoGlobalNode.brs
+
 sub init()
   _global = KopytkoGlobalNode()
   _global.addFields({
@@ -21,24 +21,21 @@ sub navigate(data as Object)
     _updateHistory()
   end if
 
-  if (NOT m.top.activatedRoute.shouldSkip)
-    m.top.previousRoute = NodeUtils().cloneNode(m.top.activatedRoute)
-  end if
-
-  m.top.activatedRoute.path = data.path
-  m.top.activatedRoute.params = ternary(data.params <> Invalid, data.params, {})
+  ' Needs to be set before activatedRoute as setPreviousRoute uses the previous value of activatedRoute.
+  m.top.previousRoute = _getPreviousRoute(data)
+  m.top.activatedRoute.path = getProperty(data, "path", "")
+  m.top.activatedRoute.params = getProperty(data, "params", {})
   m.top.activatedRoute.backJourneyData = data.backJourneyData
   m.top.activatedRoute.isBackJourney = getProperty(data, "isBackJourney", false)
   m.top.activatedRoute.shouldSkip = false
-  m.top.activatedRoute.virtualPath = ""
+  m.top.activatedRoute.virtualPath = getProperty(data, "virtualPath", "")
   m.top.url = url
 end sub
 
 function back(data = {} as Object) as Boolean
   previousLocation = m._history.pop()
-  if (previousLocation = Invalid)
-    return false
-  end if
+
+  if (previousLocation = Invalid) then return false
 
   previousLocation.skipInHistory = true
   previousLocation.isBackJourney = true
@@ -51,22 +48,45 @@ sub resetHistory(rootPath = "" as String)
   m._history = []
 
   if (rootPath <> "")
-    m._history.push({ path: rootPath, params: {} })
+    rootRoute = CreateObject("roSGNode", "ActivatedRoute")
+    rootRoute.setFields({ path: rootPath })
+
+    m._history.push(rootRoute.getFields())
   end if
 end sub
 
-sub _updateHistory()
-  if (m.top.url = "" OR m.top.activatedRoute.shouldSkip)
-    return
+function _getPreviousRoute(data as Object) as Object
+  isBackJourney = getProperty(data, "isBackJourney", false)
+
+  if (isBackJourney OR m.top.activatedRoute.shouldSkip)
+    previousRoute = CreateObject("roSGNode", "ActivatedRoute")
+    previousRouteData = m._history[m._history.count() - 1]
+
+    if (previousRouteData = Invalid) then return Invalid
+
+    previousRoute.setFields(previousRouteData)
+
+    return previousRoute
   end if
+
+  return NodeUtils().cloneNode(m.top.activatedRoute)
+end function
+
+sub _updateHistory()
+  if (m.top.url = "" OR m.top.activatedRoute.shouldSkip) then return
 
   m._history.push(_createHistoryItem(m.top.activatedRoute))
 end sub
 
 function _createHistoryItem(route as Object) as Object
-  return {
-    path: route.path,
-    params: route.params,
-    backJourneyData: route.backJourneyData,
-  }
+  historyItem = route.getFields()
+  _deleteKeys(historyItem, ["change", "focusable", "focusedChild", "id"])
+
+  return historyItem
 end function
+
+sub _deleteKeys(assocArray as Object, keys as Object)
+  for each key in keys
+    assocArray.delete(key)
+  end for
+end sub

--- a/src/components/router/Router.brs
+++ b/src/components/router/Router.brs
@@ -13,27 +13,27 @@ sub init()
   m._history = []
 end sub
 
-sub navigate(data as Object)
-  url = buildUrl(data.path, data.params)
+sub navigate(navigateData as Object)
+  url = buildUrl(navigateData.path, navigateData.params)
   if (url = m.top.url) then return ' Avoid doubling url
 
-  if (data.skipInHistory = Invalid OR (NOT data.skipInHistory))
+  if (navigateData.skipInHistory = Invalid OR (NOT navigateData.skipInHistory))
     _updateHistory()
   end if
 
   ' Needs to be set before activatedRoute as _getPreviousRoute uses the previous value of activatedRoute.
-  m.top.previousRoute = _getPreviousRoute(data)
+  m.top.previousRoute = _getPreviousRoute(navigateData)
 
-  m.top.activatedRoute.path = getProperty(data, "path", "")
-  m.top.activatedRoute.params = getProperty(data, "params", {})
-  m.top.activatedRoute.backJourneyData = data.backJourneyData
-  m.top.activatedRoute.isBackJourney = getProperty(data, "isBackJourney", false)
+  m.top.activatedRoute.path = getProperty(navigateData, "path", "")
+  m.top.activatedRoute.params = getProperty(navigateData, "params", {})
+  m.top.activatedRoute.backJourneyData = navigateData.backJourneyData
+  m.top.activatedRoute.isBackJourney = getProperty(navigateData, "isBackJourney", false)
   m.top.activatedRoute.shouldSkip = false
-  m.top.activatedRoute.virtualPath = getProperty(data, "virtualPath", "")
+  m.top.activatedRoute.virtualPath = getProperty(navigateData, "virtualPath", "")
   m.top.url = url
 end sub
 
-function back(data = {} as Object) as Boolean
+function back(_backData = {} as Object) as Boolean
   previousLocation = m._history.pop()
 
   if (previousLocation = Invalid) then return false

--- a/src/components/router/Router.brs
+++ b/src/components/router/Router.brs
@@ -21,13 +21,15 @@ sub navigate(navigateData as Object)
     _updateHistory()
   end if
 
+  isBackJourney = getProperty(navigateData, "isBackJourney", false)
+
   ' Needs to be set before activatedRoute as _getPreviousRoute uses the previous value of activatedRoute.
-  m.top.previousRoute = _getPreviousRoute(navigateData)
+  m.top.previousRoute = _getPreviousRoute(isBackJourney)
 
   m.top.activatedRoute.path = getProperty(navigateData, "path", "")
   m.top.activatedRoute.params = getProperty(navigateData, "params", {})
   m.top.activatedRoute.backJourneyData = navigateData.backJourneyData
-  m.top.activatedRoute.isBackJourney = getProperty(navigateData, "isBackJourney", false)
+  m.top.activatedRoute.isBackJourney = isBackJourney
   m.top.activatedRoute.shouldSkip = false
   m.top.activatedRoute.virtualPath = getProperty(navigateData, "virtualPath", "")
   m.top.url = url
@@ -55,9 +57,7 @@ sub resetHistory(rootPath = "" as String)
   end if
 end sub
 
-function _getPreviousRoute(navigationData as Object) as Object
-  isBackJourney = getProperty(navigationData, "isBackJourney", false)
-
+function _getPreviousRoute(isBackJourney as Boolean) as Object
   if (isBackJourney OR m.top.activatedRoute.shouldSkip)
     return _createRoute(m._history.peek())
   end if

--- a/src/components/router/_tests/Router.test.brs
+++ b/src/components/router/_tests/Router.test.brs
@@ -1,5 +1,6 @@
 ' @import /components/KopytkoFrameworkTestSuite.brs from @dazn/kopytko-unit-testing-framework
 ' @mock /components/utils/KopytkoGlobalNode.brs
+
 function TestSuite__Router() as Object
   ts = KopytkoFrameworkTestSuite()
   ts.name = "Router"
@@ -55,11 +56,11 @@ function TestSuite__Router() as Object
       path: "/previous-path",
       params: { previousParam: "previousValue" },
       backJourneyData: { data: "kopytko" },
-      isBackJourney: true,
+      isBackJourney: false,
       shouldSkip: false,
       virtualPath: "/virtual-path",
     }
-    m.top.activatedRoute.setFields(data)
+    navigate(data)
 
     ' When
     navigate({ path: "new-path" })
@@ -160,6 +161,38 @@ function TestSuite__Router() as Object
     return ts.assertTrue(result)
   end function)
 
+  ts.addTest("back - sets proper previousRoute", function (ts as Object) as String
+    ' Given
+    data = {
+      path: "/old-path",
+      params: { previousParam: "oldValue" },
+      backJourneyData: { data: "old" },
+      isBackJourney: false,
+      shouldSkip: false,
+      virtualPath: "/virtual-path",
+    }
+    navigate(data)
+    navigate({ path: "new-path" })
+    navigate({ path: "newest-path" })
+
+    ' When
+    back()
+
+    ' Then
+    previousRoute = m.top.previousRoute
+    actual = {
+      backJourneyData: previousRoute.backJourneyData,
+      isBackJourney: previousRoute.isBackJourney,
+      params: previousRoute.params,
+      path: previousRoute.path,
+      shouldSkip: previousRoute.shouldSkip,
+      virtualPath: previousRoute.virtualPath,
+    }
+    expected = data
+
+    return ts.assertEqual(actual, expected)
+  end function)
+
   ts.addTest("back - returns false if empty history", function (ts as Object) as String
     result = back()
 
@@ -244,6 +277,7 @@ end function
 
 sub RouterTestSuite__TearDown(ts as Object)
   m.top.activatedRoute = CreateObject("roSGNode", "ActivatedRoute")
+  m.top.previousRoute = Invalid
   m.top.url = "/"
 
   m._history = []


### PR DESCRIPTION
## What did you implement:

Closes [#56](https://github.com/getndazn/kopytko-framework/issues/56)

## How did you implement it:

Save the latest item from kept history items instead of the current `activeRoute`.
It will also do that if the `activeRoute` should be skipped in the history.

## How can we verify it:

The `previousRoute` should have the correct value always.

## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
