### PR TITLE
fix: isCachingEnabled checks incorrect options object

### DIFF
--- a/src/components/http/HttpRequest.brs
+++ b/src/components/http/HttpRequest.brs
@@ -148,7 +148,7 @@ function HttpRequest(options as Object, httpInterceptors = [] as Object) as Obje
 
   ' @returns {Boolean}
   prototype.isCachingEnabled = function () as Boolean
-    return getProperty(m.options, "enableCaching", true)
+    return getProperty(m._options, "enableCaching", true)
   end function
 
   prototype.setHeader = sub (name as String, value as Dynamic)

--- a/src/components/http/_tests/HttpRequest.test.brs
+++ b/src/components/http/_tests/HttpRequest.test.brs
@@ -260,6 +260,39 @@ function TestSuite__HttpRequest() as Object
     return ts.assertMethodWasCalled("UrlTransfer.asyncCancel")
   end function)
 
+  ts.addTest("isCachingEnabled - should enable caching by default", function (ts as Object) as String
+    ' Given
+    options = {
+      id: "123456",
+      url: "http://test.com",
+      method: "GET",
+    }
+
+    ' When
+    request = HttpRequest(options)
+    request.send()
+
+    ' Then
+    return ts.assertTrue(request.isCachingEnabled())
+  end function)
+
+  ts.addTest("isCachingEnabled - should disable caching", function (ts as Object) as String
+    ' Given
+    options = {
+      id: "123456",
+      url: "http://test.com",
+      method: "GET",
+      enableCaching: false,
+    }
+
+    ' When
+    request = HttpRequest(options)
+    request.send()
+
+    ' Then
+    return ts.assertFalse(request.isCachingEnabled())
+  end function)
+
   ts.addTest("cancel - should cancel request", function (ts as Object) as String
     ' Given
     options = {


### PR DESCRIPTION
## How did you implement it:

`isCachingEnabled` access proper options object

## How can we verify it:

request `enableCaching` option set to false now disables caching

## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
