### PR TITLE
feat!: add componentDidCatch for error handling

### DIFF
--- a/.kopytkorc
+++ b/.kopytkorc
@@ -1,5 +1,5 @@
 {
-  "baseManifest": "./node_modules/@dazn/kopytko-unit-testing-framework/manifest.js",
+  "baseManifest": "./manifest.js",
   "sourceDir": "./src",
   "pluginDefinitions": {
     "generate-tests": "./node_modules/@dazn/kopytko-unit-testing-framework/plugins/generate-tests"

--- a/docs/renderer.md
+++ b/docs/renderer.md
@@ -182,6 +182,9 @@ these methods are called lifecycle methods:
       ' The info object containing
       ' componentMethod - component method where the error has been thrown
       ' componentName - node name that extends KopytkoGroup or KopytkoLayoutGroup
+      ' componentProps - current component properties
+      ' componentState - current component state
+      ' componentVirtualDOM - current component virtual DOM
       ?info
     end sub
   ```

--- a/docs/renderer.md
+++ b/docs/renderer.md
@@ -173,6 +173,19 @@ these methods are called lifecycle methods:
     end sub
   ```
 
+- `componentDidCatch(error as Object, info as Object)` - called when a component method has thrown an error
+  ```brightscript
+    sub componentDidCatch(error as Object, info as Object)
+      ' The Roku exception object
+      ' https://developer.roku.com/docs/references/brightscript/language/error-handling.md#the-exception-object
+      ?error
+      ' The info object containing
+      ' componentMethod - component method where the error has been thrown
+      ' componentName - node name that extends KopytkoGroup or KopytkoLayoutGroup
+      ?info
+    end sub
+  ```
+
 Creating a tree of elements results in calling `constructor` method starting from the parent to children
 and then `componentDidMount` in the opposite order - from children to the parent.
 

--- a/docs/renderer.md
+++ b/docs/renderer.md
@@ -174,6 +174,9 @@ these methods are called lifecycle methods:
   ```
 
 - `componentDidCatch(error as Object, info as Object)` - called when a component method has thrown an error
+
+  IMPORTANT: This catch will only work with **bs_const** `enableKopytkoComponentDidCatch: true` in the **manifest** file.
+
   ```brightscript
     sub componentDidCatch(error as Object, info as Object)
       ' The Roku exception object

--- a/docs/versions-migration-guide.md
+++ b/docs/versions-migration-guide.md
@@ -1,10 +1,20 @@
-# Update Kopytko Framework to v2
+# Update Kopytko Framework
 
-## Highlighted breaking changes in Kopytko Framework v2
+## Update from v2 to v3
+
+Version 3 introduced the `componentDidCatch` lifecycle method. It is not needed to implement componentDidCatch, but there could be a scenario where it is implemented and a developer wants to disable it (for example, for the development time). Because of that there is a new **bs_const** that needs to be defined in the **manifest** file - `enableKopytkoComponentDidCatch`.
+
+`enableKopytkoComponentDidCatch: true` - **enables** the `componentDidCatch` method
+
+`enableKopytkoComponentDidCatch: false` - **disables** the `componentDidCatch` method
+
+## Update from v1 to v2
+
+### Highlighted breaking changes in Kopytko Framework v2
+
 There were no interface changes making Kopytko Framework v2 a breaking change, but, because Kopytko Packager so far doesn't handle components and functions namespacing, the introduced new [`HttpRequest`](../src/components/http/request/Http.request.xml) component may cause name collision. It can happen if there already exist a HttpRequest component in the application the framework is used and it is very probable as Kopytko team was recommending creating own HttpRequest extending the [`Request`](../src/components/http/request/Request.xml) component. We came across Kopytko users' needs and created a helpful `HttpRequest` component implementing all necessary mechanisms to make an HTTP(S) call - we recommend switching over to Kopytko's `HttpRequest` component as soon as possible.
 
-
-## Deprecations highlights in Kopytko Framework v2
+### Deprecations highlights in Kopytko Framework v2
 
 These APIs remain available in v2, but will be removed in future versions.
 

--- a/manifest.js
+++ b/manifest.js
@@ -1,0 +1,9 @@
+const baseManifest = require('@dazn/kopytko-unit-testing-framework/manifest');
+
+module.exports = {
+  ...baseManifest,
+  bs_const: {
+    ...baseManifest.bs_const,
+    enableKopytkoComponentDidCatch: false,
+  },
+}

--- a/src/components/renderer/Kopytko.brs
+++ b/src/components/renderer/Kopytko.brs
@@ -21,7 +21,12 @@ sub initKopytko(dynamicProps = {} as Object, componentsMapping = {} as Object)
   m.top.observeFieldScoped("focusedChild", "focusDidChange")
   m.top.update(dynamicProps)
 
-  constructor()
+  try
+    constructor()
+  catch error
+    _throw(error, "constructor")
+  end try
+
   m._previousState = _cloneObject(m.state) ' required because of setting default state in constructor()
 
   _mountComponent()
@@ -32,7 +37,11 @@ end sub
 sub destroyKopytko(data = {} as Object)
   if (NOT m._isInitialized) then return
 
-  componentWillUnmount()
+  try
+    componentWillUnmount()
+  catch error
+    _throw(error, "componentWillUnmount")
+  end try
 
   if (m["$$eventBus"] <> Invalid)
     m["$$eventBus"].clear()
@@ -41,7 +50,12 @@ sub destroyKopytko(data = {} as Object)
   m.state = {}
   m._previousState = {}
   m.top.unobserveFieldScoped("focusedChild")
-  m._kopytkoUpdater.destroy()
+
+  try
+    m._kopytkoUpdater.destroy()
+  catch error
+    _throw(error, "destroyKopytko")
+  end try
 
   _clearDOM()
 
@@ -66,6 +80,10 @@ end sub
 sub componentWillUnmount()
 end sub
 
+sub componentDidCatch(error as Object, _info as Object)
+  throw error
+end sub
+
 sub focusDidChange(event as Object)
   if (m.top.hasFocus() AND m.elementToFocus <> Invalid)
     m.elementToFocus.setFocus(true)
@@ -73,15 +91,27 @@ sub focusDidChange(event as Object)
 end sub
 
 sub setState(partialState as Object, callback = Invalid as Dynamic)
-  m._kopytkoUpdater.enqueueStateUpdate(partialState, callback)
+  try
+    m._kopytkoUpdater.enqueueStateUpdate(partialState, callback)
+  catch error
+    _throw(error, "setState")
+  end try
 end sub
 
 sub forceUpdate()
-  m._kopytkoUpdater.forceStateUpdate()
+  try
+    m._kopytkoUpdater.forceStateUpdate()
+  catch error
+    _throw(error, "forceUpdate")
+  end try
 end sub
 
 sub enqueueUpdate()
-  m._kopytkoUpdater.enqueueStateUpdate()
+  try
+    m._kopytkoUpdater.enqueueStateUpdate()
+  catch error
+    _throw(error, "enqueueUpdate")
+  end try
 end sub
 
 sub updateProps(props = {} as Object)
@@ -92,10 +122,24 @@ end sub
 
 sub _mountComponent()
   m._virtualDOM = render()
-  m._kopytkoDOM.renderElement(m._virtualDOM, m.top)
 
-  m._kopytkoUpdater.setComponentMounted(m.state)
-  componentDidMount()
+  try
+    m._kopytkoDOM.renderElement(m._virtualDOM, m.top)
+  catch error
+    _throw(error, "renderElement")
+  end try
+
+  try
+    m._kopytkoUpdater.setComponentMounted(m.state)
+  catch error
+    _throw(error, "setComponentMounted")
+  end try
+
+  try
+    componentDidMount()
+  catch error
+    _throw(error, "componentDidMount")
+  end try
 end sub
 
 sub _onStateUpdated()
@@ -114,8 +158,20 @@ sub _updateDOM()
     m.top.setFocus(true)
   end if
 
-  componentDidUpdate(m._previousProps, m._previousState)
+  try
+    componentDidUpdate(m._previousProps, m._previousState)
+  catch error
+    _throw(error, "componentDidUpdate")
+  end try
+
   m._previousState = _cloneObject(m.state)
+end sub
+
+sub _throw(error as Object, failingComponentMethod as String)
+  componentDidCatch(error, {
+    componentMethod: failingComponentMethod,
+    componentName: m.top.subtype(),
+  })
 end sub
 
 sub _clearDOM()

--- a/src/components/renderer/Kopytko.brs
+++ b/src/components/renderer/Kopytko.brs
@@ -1,8 +1,10 @@
+' @import /components/functionCall.brs from @dazn/kopytko-utils
+
 sub init()
   m.state = {}
   m.elementToFocus = Invalid
 
-  m._enabledErrorHandling = Type(componentDidCatch) <> "<uninitialized>"
+  m._enabledErrorCatching = Type(componentDidCatch) <> "<uninitialized>"
   m._isInitialized = false
   m._previousProps = {}
   m._previousState = {}
@@ -137,32 +139,17 @@ function _cloneObject(obj as Object) as Object
 end function
 
 sub _methodCall(func as Function, methodName as String, args = [] as Object, context = Invalid as Object)
-  if (m._enabledErrorHandling)
+  if (m._enabledErrorCatching)
     try
-      _functionCall(func, args, context)
+      functionCall(func, args, context)
     catch error
       _throw(error, methodName)
     end try
-  else
-    _functionCall(func, args, context)
-  end if
-end sub
 
-sub _functionCall(func as Function, args = [] as Object, context = Invalid as Object)
-  if (context = Invalid) then context = GetGlobalAA()
-
-  argumentsNumber = args.count()
-  context["$$functionCall"] = func
-
-  if (argumentsNumber = 0)
-    context["$$functionCall"]()
-  else if (argumentsNumber = 1)
-    context["$$functionCall"](args[0])
-  else if (argumentsNumber = 2)
-    context["$$functionCall"](args[0], args[1])
+    return
   end if
 
-  context.delete("$$functionCall")
+  functionCall(func, args, context)
 end sub
 
 sub _throw(error as Object, failingComponentMethod as String)

--- a/src/components/renderer/Kopytko.brs
+++ b/src/components/renderer/Kopytko.brs
@@ -96,7 +96,7 @@ end sub
 sub _mountComponent()
   m._virtualDOM = render()
 
-  _methodCall(m._kopytkoDOM.renderElement, "setComponentMounted", [m._virtualDOM, m.top], m._kopytkoDOM)
+  _methodCall(m._kopytkoDOM.renderElement, "renderElement", [m._virtualDOM, m.top], m._kopytkoDOM)
   _methodCall(m._kopytkoUpdater.setComponentMounted, "setComponentMounted", [m.state], m._kopytkoUpdater)
   _methodCall(componentDidMount, "componentDidMount")
 end sub

--- a/src/components/renderer/Kopytko.brs
+++ b/src/components/renderer/Kopytko.brs
@@ -156,5 +156,8 @@ sub _throw(error as Object, failingComponentMethod as String)
   componentDidCatch(error, {
     componentMethod: failingComponentMethod,
     componentName: m.top.subtype(),
+    componentProps: m.top.getFields(),
+    componentState: m.state,
+    componentVirtualDOM: m._virtualDOM,
   })
 end sub

--- a/src/components/renderer/Kopytko.brs
+++ b/src/components/renderer/Kopytko.brs
@@ -4,12 +4,7 @@ sub init()
   m.state = {}
   m.elementToFocus = Invalid
 
-  m._enabledErrorCatching = false
-  #if enableKopytkoComponentDidCatch
-    m._enabledErrorCatching = true
-  #end if
-  m._enabledErrorCatching = m._enabledErrorCatching AND Type(componentDidCatch) <> "<uninitialized>"
-
+  m._enabledErrorCatching = _isComponentDidCatchEnabled()
   m._isInitialized = false
   m._previousProps = {}
   m._previousState = {}
@@ -141,6 +136,16 @@ function _cloneObject(obj as Object) as Object
   newObj.append(obj)
 
   return newObj
+end function
+
+function _isComponentDidCatchEnabled() as Boolean
+  isComponentDidCatchEnabled = false
+
+  #if enableKopytkoComponentDidCatch
+    isComponentDidCatchEnabled = true
+  #end if
+
+  return isComponentDidCatchEnabled AND Type(componentDidCatch) <> "<uninitialized>"
 end function
 
 sub _methodCall(func as Function, methodName as String, args = [] as Object, context = Invalid as Object)

--- a/src/components/renderer/Kopytko.brs
+++ b/src/components/renderer/Kopytko.brs
@@ -4,7 +4,12 @@ sub init()
   m.state = {}
   m.elementToFocus = Invalid
 
-  m._enabledErrorCatching = Type(componentDidCatch) <> "<uninitialized>"
+  m._enabledErrorCatching = false
+  #if enableKopytkoComponentDidCatch
+    m._enabledErrorCatching = true
+  #end if
+  m._enabledErrorCatching = m._enabledErrorCatching AND Type(componentDidCatch) <> "<uninitialized>"
+
   m._isInitialized = false
   m._previousProps = {}
   m._previousState = {}


### PR DESCRIPTION
BREAKING CHANGE: Add `enableKopytkoComponentDidCatch` **bs_const** to the manifest file

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

The new Lifecycle method `componentDidCatch` is invoked when the error is thrown within the component.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:


`componentDidCatch(error as Object, info as Object)`

```brightscript
  sub componentDidCatch(error as Object, info as Object)
    ' The Roku exception object
    ' https://developer.roku.com/docs/references/brightscript/language/error-handling.md#the-exception-object
    ?error
    ' The info object containing
    ' componentMethod - component method where the error has been thrown
    ' componentName - node name that extends KopytkoGroup or KopytkoLayoutGroup
    ?info
  end sub
```

## How can we verify it:

Create a component, add `componentDidCatch` method, and make the component throw an error.

`componentDidCatch` implementation

```brightscript
sub componentDidCatch(error as Object, info as Object)
  ?info
  ?error
end sub
```

example of throwing an error`componentDidMount` implementation

```brightscript
sub componentDidMount()
  variable = m.some.not.existing.nested.object
end sub
```

## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES
