### PR TITLE
feat: add bodyString to the http request options

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -71,6 +71,7 @@ Request options structure allowed to be returned by `getRequestOptions` function
 - `headers` - associative array - headers fields
 - `method` - string - HTTP method
 - `body` - associative array - request body
+- `bodyString` - string - request body string, alternative for `body`
 - `queryParams` - associative array - with  query params
 - `compression` - (defalt: true) boolean - indicating if the request should be compressed
 - `timeout` - integer - time after which request should be aborted

--- a/src/components/http/HttpRequest.brs
+++ b/src/components/http/HttpRequest.brs
@@ -1,5 +1,6 @@
 ' @import /components/buildUrl.brs from @dazn/kopytko-utils
 ' @import /components/getProperty.brs from @dazn/kopytko-utils
+' @import /components/getType.brs from @dazn/kopytko-utils
 ' @import /components/rokuComponents/Timespan.brs from @dazn/kopytko-utils
 ' @import /components/rokuComponents/UrlTransfer.brs from @dazn/kopytko-utils
 ' @import /components/ternary.brs from @dazn/kopytko-utils
@@ -52,7 +53,7 @@ function HttpRequest(options as Object, httpInterceptors = [] as Object) as Obje
       m._urlTransfer.initClientCertificates()
     end if
 
-    if (Type(m._options.headers) = "roAssociativeArray")
+    if (getType(m._options.headers) = "roAssociativeArray")
       m._headers.append(m._options.headers)
     end if
 
@@ -80,7 +81,7 @@ function HttpRequest(options as Object, httpInterceptors = [] as Object) as Obje
 
       if (m._options.body <> Invalid)
         body = FormatJSON(m._options.body)
-      else if (m._options.bodyString <> Invalid)
+      else if (getType(m._options.bodyString) = "roString")
         body = m._options.bodyString
       end if
 

--- a/src/components/http/HttpRequest.brs
+++ b/src/components/http/HttpRequest.brs
@@ -13,6 +13,7 @@
 ' @property {Object} headers
 ' @property {Integer} timeout
 ' @property {Object} body
+' @property {String} bodyString
 
 ' Request logic.
 ' @class
@@ -79,6 +80,8 @@ function HttpRequest(options as Object, httpInterceptors = [] as Object) as Obje
 
       if (m._options.body <> Invalid)
         body = FormatJSON(m._options.body)
+      else if (m._options.bodyString <> Invalid)
+        body = m._options.bodyString
       end if
 
       m._urlTransfer.asyncPostFromString(body)


### PR DESCRIPTION
Add bodyString to the request options, allowing to passa  string for the body directly instead of parsing it through the framework.

## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
