### PR TITLE
fix: schedule re-render when setState is called before component mount

### DIFF
--- a/docs/renderer.md
+++ b/docs/renderer.md
@@ -95,8 +95,13 @@ The `setState` method accepts also a callback function argument with the code to
 and re-rendered.
 
 Please note that in an edge case, because children event listeners are set before the parent component is mounted,
-it is possible that the `setState` method is called before the component was mounted. In such case, state update
-will be delayed right after the `componentDidMount` lifecycle method call.
+it is possible that the `setState` method is called before the component was mounted. A common trigger is Roku's
+`observeFieldScoped` platform behaviour: if a field already holds a non-default value at the time the observation
+is registered, the callback fires **synchronously** in the same call stack. This can happen when a child component
+fetches data from cache and sets a result field before the parent has finished mounting.
+
+In this case the partial state is queued internally, applied to the component state in `setComponentMounted`, and a
+re-render is scheduled automatically on the next processor tick — after `componentDidMount` has returned.
 
 An example usage of the component state in the render() method:
 ```brightscript

--- a/src/components/renderer/KopytkoUpdater.brs
+++ b/src/components/renderer/KopytkoUpdater.brs
@@ -31,12 +31,19 @@ function KopytkoUpdater(baseStateUpdatedCallback as Function)
   prototype.setComponentMounted = sub (state as Object)
     m._state = state ' can't be passed in Updater constructor because it's assigned in constructor of Kopytko component
 
+    hasPendingStates = m._pendingPartialStates.count() > 0
     for each partialState in m._pendingPartialStates
       m._state.append(partialState)
     end for
 
     m._pendingPartialStates.clear()
-    ' No need to setup _onStateUpdated because it will be called in the next tick if there was any state update enqueued
+
+    ' If setState was called before mount (e.g. a child fired an observeFieldScoped callback synchronously
+    ' during renderElement), enqueueStateUpdate returned early and never scheduled a re-render.
+    ' Schedule one now so the component renders with the correct initial state.
+    if (hasPendingStates AND NOT m._isUpdating())
+      m._stateUpdateTimeoutId = setTimeoutCore(m._onStateUpdated, 0, m)
+    end if
   end sub
 
   prototype.destroy = sub ()

--- a/src/components/renderer/_tests/KopytkoUpdater.test.brs
+++ b/src/components/renderer/_tests/KopytkoUpdater.test.brs
@@ -248,6 +248,31 @@ function TestSuite__KopytkoUpdater()
     return ts.assertEqual(m.__state, { test: "value", another: "value" })
   end function)
 
+  ts.addTest("setComponentMounted schedules a re-render in the next tick if setState was called before mount", function (ts as Object) as String
+    ' Given
+    updater = KopytkoUpdater(baseStateUpdatedCallback)
+    updater.enqueueStateUpdate({ test: "value" })
+
+    ' When
+    updater.setComponentMounted(m.__state)
+    m.__clock.tick()
+
+    ' Then
+    return ts.assertMethodWasCalled("baseStateUpdatedCallback", {}, { times: 1 })
+  end function)
+
+  ts.addTest("setComponentMounted does not schedule a re-render if no setState was called before mount", function (ts as Object) as String
+    ' Given
+    updater = KopytkoUpdater(baseStateUpdatedCallback)
+
+    ' When
+    updater.setComponentMounted(m.__state)
+    m.__clock.tick()
+
+    ' Then
+    return ts.assertMethodWasNotCalled("baseStateUpdatedCallback")
+  end function)
+
   ts.addTest("destroy cancels all enqueued state update callbacks", function (ts as Object) as String
     ' Given
     updater = KopytkoUpdater(baseStateUpdatedCallback)


### PR DESCRIPTION
When a child component fires an observeFieldScoped callback synchronously during the parent's renderElement (e.g. a cache-hit result field is already set when the observation is registered), setState is called on the parent before setComponentMounted has run. enqueueStateUpdate correctly stored the partial state in _pendingPartialStates but returned early before scheduling a re-render timer, so the component never re-rendered after mount.

Fix: track whether there were any pending states in setComponentMounted and, if so, schedule a setTimeoutCore(0) re-render — matching the behaviour that enqueueStateUpdate would have produced had the component already been mounted.

Also adds two regression tests and expands the renderer.md documentation to describe the observeFieldScoped synchronous-callback platform behaviour that triggers this edge case.